### PR TITLE
[experimental] Support data type as MXFP4 and MXFP6

### DIFF
--- a/deepcompressor/quantizer/impl/mx.py
+++ b/deepcompressor/quantizer/impl/mx.py
@@ -1,0 +1,68 @@
+import struct
+import torch
+
+# Constants based on the provided macros
+FLOAT32_EXP_BIAS = 127
+FLOAT32_EXP_MAX = 255
+FLOAT32_TRAILING_MBITS = 23
+FLOAT32_IMPLIED1 = (1 << FLOAT32_TRAILING_MBITS)
+FLOAT32_FULL_MBITS = (FLOAT32_TRAILING_MBITS + 1)
+FLOAT32_INF = 0x7fe00000
+FLOAT32_EXP_OFFSET = 23
+FLOAT32_SIGN_OFFSET = 31
+FLOAT32_EXP_MASK = 0x7f800000
+FLOAT32_MANTISSA_MASK = 0x007fffff
+
+# RoundMode is assumed to be an integer, you can define it based on your specific use case.
+RoundMode = int  # This can be further defined if you have specific enum values for rounding modes.
+
+from torch.utils.cpp_extension import load
+import torch
+
+import os
+os.environ['PATH'] = '/usr/lib/cuda/bin:' + os.environ['PATH']
+
+extra_cflags = ["-DUSE_CUDA"]
+extra_cuda_cflags = ["-DUSE_CUDA"]
+
+mx = load(name="mx",
+               sources=[
+                        "deepcompressor/quantizer/impl/mx/funcs.cpp",
+                        "deepcompressor/quantizer/impl/mx/funcs.cu"
+                        ],
+               extra_cuda_cflags=extra_cuda_cflags,
+               extra_cflags=extra_cflags,
+               extra_include_paths=[
+                   "/group/amdneuralopt/zhaofeng/tools/miniconda3/envs/deepcompressor/lib/python3.12/site-packages/triton/backends/nvidia/include/",
+                   ],
+               verbose=True)
+
+
+def get_dtype_params(dtype: str) -> tuple[int, int, int]:
+    if dtype == "fp6_e3m2_all":
+        ebits, mbits = 3, 2
+        emax = 2**(ebits - 1)
+    elif dtype == "sfp6_e2m3_all":
+        ebits, mbits = 2, 3
+        emax = 2**(ebits - 1)
+    elif dtype == "sfp4_e2m1_all":
+        ebits, mbits = 2, 1
+        emax = 2**(ebits - 1)
+    else:
+        raise Exception("Unknown element format %s" % dtype)
+
+    return ebits, mbits, emax
+
+
+
+def fake_quantize_mx(input_tensor, scale, element_dtype):
+    ebits, mbits, _ = get_dtype_params(element_dtype)
+    max_exp = pow(2.0, ebits) - 1
+    offset_exp = pow(2.0, ebits - 1) - 1
+    quant_max = pow(2.0, max_exp - offset_exp) * (1 + (pow(2.0, mbits) - 1) / (pow(2.0, mbits)))
+
+    input_tensor = input_tensor / scale
+
+    output_tensor = mx.fake_quantize_to_low_precision_fp(input_tensor.contiguous(), ebits, mbits, quant_max, 0)
+
+    return output_tensor

--- a/deepcompressor/quantizer/impl/mx/funcs.cpp
+++ b/deepcompressor/quantizer/impl/mx/funcs.cpp
@@ -1,0 +1,55 @@
+//
+// Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+
+#include <ATen/ATen.h>
+#include <torch/extension.h>
+#include "funcs.cuh"
+
+void fake_quantize_to_low_precision_fp_cpu(
+    float * input,
+    float * output,
+    uint32_t num_elements,
+    int ebits,
+    int mbits,
+    float max_norm,
+    RoundMode round_mode
+) {
+for (int i = 0; i < num_elements; i++) {
+    output[i] = fake_quantize_element(input[i], max_norm, ebits, mbits, round_mode);
+}
+}
+
+torch::Tensor fake_quantize_to_low_precision_fp(
+    torch::Tensor &input,
+    int ebits,
+    int mbits,
+    float max_norm,
+    uint32_t round_mode
+) {
+float * input_data = input.data_ptr<float>();
+torch::Tensor output = torch::empty_like(input);
+float * output_data = output.data_ptr<float>();
+#ifdef USE_CUDA
+if (input.is_cpu()) {
+    fake_quantize_to_low_precision_fp_cpu(input_data, output_data, input.numel(), ebits, mbits, max_norm, (RoundMode)round_mode);
+} else {
+    const at::cuda::OptionalCUDAGuard device_guard(device_of(input));
+    fake_quantize_to_low_precision_fp_cuda(input_data, output_data, input.numel(), ebits, mbits, max_norm, (RoundMode)round_mode);
+}
+#else
+fake_quantize_to_low_precision_fp_cpu(input_data, output_data, input.numel(), ebits, mbits, max_norm, (RoundMode)round_mode);
+#endif
+return output;
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+    m.def("fake_quantize_to_low_precision_fp", &fake_quantize_to_low_precision_fp, "fake_quantize_to_low_precision_fp",
+          py::arg("input"),
+          py::arg("ebits"),
+          py::arg("mbits"),
+          py::arg("max_norm"),
+          py::arg("round_mode")
+    );
+  }

--- a/deepcompressor/quantizer/impl/mx/funcs.cu
+++ b/deepcompressor/quantizer/impl/mx/funcs.cu
@@ -1,0 +1,37 @@
+//
+// Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+#include <c10/cuda/CUDAGuard.h>
+#include "funcs.cuh"
+
+__global__ void fake_quantize_kernel(
+    float * input,
+    float * output,
+    uint32_t num_elements,
+    int ebits,
+    int mbits,
+    float max_norm,
+    RoundMode round_mode
+) {
+    int index = blockDim.x * blockIdx.x + threadIdx.x;
+    if (index >= num_elements) {
+        return;
+    }
+    output[index] = fake_quantize_element(input[index], max_norm, ebits, mbits, round_mode);
+}
+
+void fake_quantize_to_low_precision_fp_cuda(
+    float * input,
+    float * output,
+    uint32_t num_elements,
+    int ebits,
+    int mbits,
+    float max_norm,
+    RoundMode round_mode
+) {
+    int blocks = num_elements % THREADS_PER_BLOCK == 0 ? num_elements / THREADS_PER_BLOCK : num_elements / THREADS_PER_BLOCK + 1;
+    fake_quantize_kernel<<<blocks, THREADS_PER_BLOCK>>>(
+        input, output, num_elements, ebits, mbits, max_norm, round_mode
+    );
+}

--- a/deepcompressor/quantizer/impl/mx/funcs.cuh
+++ b/deepcompressor/quantizer/impl/mx/funcs.cuh
@@ -1,0 +1,148 @@
+//
+// Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+
+#pragma once
+
+#include <stdint.h>
+
+#ifdef USE_CUDA
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <c10/cuda/CUDAGuard.h>
+#endif
+
+#define FLOAT32_EXP_BIAS 127
+#define FLOAT32_EXP_MAX 255
+#define FLOAT32_TRAILING_MBITS 23
+#define FLOAT32_IMPLIED1 (1 << FLOAT32_TRAILING_MBITS)
+#define FLOAT32_FULL_MBITS (FLOAT32_TRAILING_MBITS + 1)
+#define FLOAT32_INF 0x7fe00000
+#define FLOAT32_EXP_OFFSET 23
+#define FLOAT32_SIGN_OFFSET 31
+#define FLOAT32_EXP_MASK 0x7f800000
+#define FLOAT32_MANTISSA_MASK 0x007fffff
+
+#define THREADS_PER_BLOCK 32
+
+enum RoundMode {
+    ROUND_HALF_TO_EVEN = 8
+};
+
+union u_float_int {
+    float float_val;
+    uint32_t int_val;
+};
+
+#ifdef USE_CUDA
+__host__ __device__ __forceinline__
+#else
+inline
+#endif
+int get_exponent(float f) {
+    u_float_int u;
+    u.float_val = f;
+    u.int_val &= FLOAT32_EXP_MASK;
+    return u.int_val >> FLOAT32_TRAILING_MBITS;
+}
+
+#ifdef USE_CUDA
+__host__ __device__ __forceinline__
+#else
+inline
+#endif
+uint32_t get_mantissa(float f) {
+    u_float_int u;
+    u.float_val = f;
+    return u.int_val &= FLOAT32_MANTISSA_MASK;
+}
+
+#ifdef USE_CUDA
+__host__ __device__ __forceinline__
+#else
+inline
+#endif
+uint32_t get_sign(float f) {
+    u_float_int u;
+    u.float_val = f;
+    return u.int_val >> FLOAT32_SIGN_OFFSET;
+}
+
+#ifdef USE_CUDA
+__host__ __device__ __forceinline__
+#else
+inline
+#endif
+uint32_t shift_and_round(uint32_t mantissa, int tail_bits, RoundMode round_mode) {
+    if (tail_bits == 0) return mantissa;
+    if (tail_bits > 25) return 0;
+    uint32_t half = 1 << (tail_bits - 1);
+    uint32_t tail = mantissa & ((1 << tail_bits) - 1);
+    uint32_t ret = mantissa >> tail_bits;
+    if (tail < half) return ret;
+    else if (tail > half) return ret + 1;
+    else return (ret) % 2 == 1 ? ret + 1 : ret;
+}
+
+#ifdef USE_CUDA
+__host__ __device__ __forceinline__
+#else
+inline
+#endif
+float construct_float(uint32_t sign, uint32_t exponent, uint32_t mantissa) {
+    u_float_int u;
+    u.int_val = (sign << FLOAT32_SIGN_OFFSET) + (exponent << FLOAT32_EXP_OFFSET) + (mantissa & FLOAT32_MANTISSA_MASK);
+    return u.float_val;
+}
+
+#ifdef USE_CUDA
+__host__ __device__ __forceinline__
+#else
+inline
+#endif
+float fake_quantize_element(
+    float element,
+    float max_norm,
+    int ebits,
+    int mbits,
+    RoundMode round_mode
+) {
+    int exp = get_exponent(element);
+    if (exp == FLOAT32_EXP_MAX) return element;
+    int new_bias = (1 << (ebits - 1)) - 1;
+    uint32_t mantissa = get_mantissa(element);
+    int mantissa_bits = FLOAT32_TRAILING_MBITS;
+    if (exp != 0) {
+        mantissa = (mantissa | FLOAT32_IMPLIED1);
+        mantissa_bits++;
+    }
+
+    int new_exp = exp - FLOAT32_EXP_BIAS + new_bias;
+    int exp_shift = new_exp > 0 ? 0 : 1 - new_exp;
+
+    int tail_bits = FLOAT32_TRAILING_MBITS - mbits + exp_shift;
+    mantissa = shift_and_round(mantissa, tail_bits, round_mode);
+    if (mantissa == 0) return 0.0;
+    mantissa = mantissa << tail_bits;
+    if (mantissa >= (1 << mantissa_bits)) {
+        if (exp != 0) mantissa = mantissa >> 1;
+        exp++;
+    }
+    float absolute_ret = construct_float(0, exp, mantissa);
+    if (absolute_ret > max_norm) absolute_ret = max_norm;
+
+    u_float_int u;
+    u.float_val = absolute_ret;
+    u.int_val += (get_sign(element) << FLOAT32_SIGN_OFFSET);
+    return u.float_val;
+}
+
+void fake_quantize_to_low_precision_fp_cuda(
+    float * input,
+    float * output,
+    uint32_t num_elements,
+    int ebits,
+    int mbits,
+    float max_norm,
+    RoundMode round_mode);

--- a/examples/diffusion/configs/svdquant/mxfp4.yaml
+++ b/examples/diffusion/configs/svdquant/mxfp4.yaml
@@ -1,0 +1,22 @@
+quant:
+  wgts:
+    dtype: sfp4_e2m1_all
+    group_shapes:
+    - - 1
+      - 32
+      - 1
+      - 1
+      - 1
+    scale_dtypes:
+    - ufp8_e8m0_nan
+  ipts:
+    static: false
+    dtype: sfp4_e2m1_all
+    group_shapes:
+    - - 1
+      - 32 # tensor_view_shape
+      - 1
+      - 1
+      - 1
+    scale_dtypes:
+    - ufp8_e8m0_nan

--- a/examples/diffusion/configs/svdquant/mxfp6_e2m3.yaml
+++ b/examples/diffusion/configs/svdquant/mxfp6_e2m3.yaml
@@ -1,0 +1,22 @@
+quant:
+  wgts:
+    dtype: sfp6_e2m3_all
+    group_shapes:
+    - - 1
+      - 32
+      - 1
+      - 1
+      - 1
+    scale_dtypes:
+    - ufp8_e8m0_nan
+  ipts:
+    static: false
+    dtype: sfp6_e2m3_all
+    group_shapes:
+    - - 1
+      - 32 # tensor_view_shape
+      - 1
+      - 1
+      - 1
+    scale_dtypes:
+    - ufp8_e8m0_nan


### PR DESCRIPTION
This PR adds support for MX FP4 and MX FP6 kernels for Flux models, along with the following test results:

![image](https://github.com/user-attachments/assets/e07da719-e2db-433a-a003-0af6272948a3)
